### PR TITLE
CI: Specify GITHUB_TOKEN read-only permissions in workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     name: Shellcheck

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   test-deploy:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Closes #5. This PR adds explicit GITHUB_TOKEN read-only permissions to test-install.yml and lint.yml, fixing the CodeQL security alerts #1 and #2.